### PR TITLE
Add support for transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ project/plugins/project/
 .idea
 *.iml
 results/
+
+# Mac specific
+.DS_Store

--- a/src/main/scala/org/neo4j/gatling/bolt/builder/SessionHelper.scala
+++ b/src/main/scala/org/neo4j/gatling/bolt/builder/SessionHelper.scala
@@ -5,6 +5,7 @@ import io.gatling.core.action.builder.ActionBuilder
 import io.gatling.core.session.Expression
 import io.gatling.core.structure.ScenarioContext
 import org.neo4j.gatling.bolt.CypherAction
+import org.neo4j.gatling.bolt.TransactionAction
 import org.neo4j.gatling.bolt.protocol.BoltProtocol
 
 object SessionHelper {
@@ -18,7 +19,9 @@ trait TransactionOrStatement extends ActionBuilder
 
 case class Transaction(statements: Seq[Cypher]) extends TransactionOrStatement {
   override def build(ctx: ScenarioContext, next: Action) = {
-    null
+    val statsEngine = ctx.coreComponents.statsEngine
+    val driver = ctx.protocolComponentsRegistry.components(BoltProtocol.boltProtocolKey).protocol.driver
+    TransactionAction(driver, statements, statsEngine, next)
   }
 }
 

--- a/src/test/scala/org/neo4j/gatling/bolt/BoltSpec.scala
+++ b/src/test/scala/org/neo4j/gatling/bolt/BoltSpec.scala
@@ -22,7 +22,7 @@ trait BoltSpec extends FlatSpec with ForAllTestContainer with Matchers {
   val statsEngine = new MockStatsEngine
 
 
-  override val container = GenericContainer("neo4j:latest",
+  override val container = GenericContainer("neo4j:3.5.17",
     exposedPorts = Seq(7687),
     env = Map("NEO4J_AUTH" -> "none"),
     waitStrategy = new LogMessageWaitStrategy().withRegEx(".*Started.*\\s")

--- a/src/test/scala/org/neo4j/gatling/bolt/TransactionActionSpec.scala
+++ b/src/test/scala/org/neo4j/gatling/bolt/TransactionActionSpec.scala
@@ -1,0 +1,21 @@
+package org.neo4j.gatling.bolt
+
+import io.gatling.core.Predef._
+import io.gatling.core.stats.writer.ResponseMessage
+import org.neo4j.gatling.bolt.builder.SessionHelper._
+
+class TransactionActionSpec extends BoltSpec {
+
+  "TransactionAction" should "use the request name in the log message" in {
+    val query = "CREATE (n) RETURN n"
+    val statements = Seq(cypher(query, Map.empty))
+    val action = TransactionAction(bolt, statements, statsEngine, next)
+
+    action.execute(session)
+
+    statsEngine.dataWriterMsg should have length 1
+    statsEngine.dataWriterMsg.head(session).toOption.get.asInstanceOf[ResponseMessage].name should equal(query)
+
+  }
+
+}

--- a/src/test/scala/org/neo4j/gatling/bolt/simulation/AuraTransactionSimulation.scala
+++ b/src/test/scala/org/neo4j/gatling/bolt/simulation/AuraTransactionSimulation.scala
@@ -1,0 +1,46 @@
+package org.neo4j.gatling.bolt.simulation
+
+import io.gatling.core.Predef._
+import io.gatling.core.scenario.Simulation
+import scala.concurrent.duration._
+import org.neo4j.driver.v1.GraphDatabase.driver
+import org.neo4j.driver.v1.AuthTokens.basic
+import org.neo4j.gatling.bolt.Predef._
+import org.neo4j.gatling.bolt.builder.SessionHelper._
+
+
+import scala.util.Random
+
+class ConcurrentNodeWriters extends Simulation {
+
+  val feeder = Iterator.continually(Map(
+    "email" -> (Random.alphanumeric.take(15).mkString + "@foo.com"),
+    "name" ->  Random.alphanumeric.take(15).mkString,
+    "age" -> Random.nextInt(100)
+  ))
+
+  val writerBolt = bolt(driver("bolt+routing://{DBID}.databases.neo4j.io:7687",
+    basic("{USERNAME}", "{PASSWORD}")))
+  val writerScenario = scenario("writer")
+    .feed(feeder)
+    .exec(
+      transaction(
+        cypher("CREATE (n:Person{name:$name, email:$email, age: $age})-[:Jibes]->(m:Person{name:$name, email:$email, age:$age}) RETURN n",
+          Map("name" -> "${name}", "email" -> "${email}", "age" -> "${age}")),
+        cypher("MATCH (n:Person) WHERE n.name = $name RETURN n",
+          Map("name" -> "${name}"))
+      )
+    ).pause(100 milliseconds)
+    .exec(
+      transaction(
+        cypher("MATCH (n:Person)-[:Jibes]->(m:Person) WHERE n.name = $name RETURN n,m",
+          Map("name" -> "${name}"))
+      )
+    ).pause(200 milliseconds)
+
+  setUp(
+    writerScenario.inject(
+      rampConcurrentUsers(0) to (100) during (20 seconds),
+      constantConcurrentUsers(100) during (1800 seconds)
+    ).protocols(writerBolt))
+}


### PR DESCRIPTION
This PR is my attempt to add `TransactionAction` to run some simulations again the Neo4j Aura (as we always recommend to use transaction to our customers).

Generally speaking, this is an elaborate Copy-n-Paste from the `CypherAction` inside a transaction envelop.

The next step would be adding `Sessions`, so that both `TransactionAction` and `CypherAction` could live inside one and thus we won't need to create a new session for each cypher action or for a new transaction.
 
This is my first week into Scala & Gatling & Bolt, so, please don't be too harsh! 😂 